### PR TITLE
Remove dynamic RapidSnark linkage (use static instead)

### DIFF
--- a/crates/build.rs
+++ b/crates/build.rs
@@ -65,7 +65,6 @@ fn main() {
     if !(env::var("CARGO_CFG_TARGET_OS").unwrap().contains("ios")
         || env::var("CARGO_CFG_TARGET_OS").unwrap().contains("android"))
     {
-        println!("cargo:rustc-link-lib=dylib=rapidsnark");
         println!("cargo:rustc-link-lib=dylib=fr");
         println!("cargo:rustc-link-lib=dylib=fq");
         println!("cargo:rustc-link-lib=dylib=gmp");


### PR DESCRIPTION
**Motivation:** Enable running UniFFI tests for the mopro templates reliably. Dynamic `dylib` linkage was redundant and caused rpath/loader issues that block the UniFFI tests.

**Change:** Drop the dynamic `rapidsnark` (and related) linkage on desktop. Keep static linkage everywhere. If needed in some specific circumstances, we may provide an optional, feature-enabled switch to re-enable dynamic linking if needed.

**Impact:**

* Unblock UniFFI tests (no rpath or env juggling).
* Consistent packaging with mobile targets.
* Slightly larger artifacts and marginally slower links are acceptable trade-offs.
